### PR TITLE
spelling mistake | et -> set

### DIFF
--- a/mountain/config/zathura/zathurarc
+++ b/mountain/config/zathura/zathurarc
@@ -1,5 +1,5 @@
 set font			"mononoki Nerd Font 10"
-et selection-notification	"true"
+set selection-notification	"true"
 set selection-clipboard		"clipboard"
 set guioptions			"sv"
 set scroll-page-aware		"true"


### PR DESCRIPTION
There was a small spelling mistake (et instead of set) which didn't really have any consequences since selection-notification seems to be enabled by default. Fixed it nevertheless. Seems to be wrong for the other colorschemes as well (only checked mountain and moonfly).