### PR TITLE
 Fix error "Parser not available for language maintained"

### DIFF
--- a/tokyo-night/config/nvim/init.vim
+++ b/tokyo-night/config/nvim/init.vim
@@ -128,7 +128,6 @@ EOF
 " ====================================================================
 lua <<EOF
 require'nvim-treesitter.configs'.setup {
-  ensure_installed = "maintained", 
   highlight = {
     enable = true,
   },


### PR DESCRIPTION
This will fix this error at the start of new neovim istance:

E5108: Error executing lua .../plugged/nvim-treesitter/lua/nvim-treesitter/install.lua:373: Parser not available for language maintained