### PR TITLE
Fix Kanagawa color scheme URL

### DIFF
--- a/kanagawa/readme.md
+++ b/kanagawa/readme.md
@@ -1,7 +1,7 @@
 ![Hero image](./images/hero.png)
 ![Badge](../images/inspired-by-kanagawa.svg)
 
-Beneath the Surface, a rice inspired by the gorgeous [Kanagawa](https://github.com/catppuccin/catppuccin) color scheme, which in turn was inspired by [_The Great Wave off Kanagawa_](https://en.wikipedia.org/wiki/The_Great_Wave_off_Kanagawa).
+Beneath the Surface, a rice inspired by the gorgeous [Kanagawa](https://github.com/rebelot/kanagawa.nvim) color scheme, which in turn was inspired by [_The Great Wave off Kanagawa_](https://en.wikipedia.org/wiki/The_Great_Wave_off_Kanagawa).
 
 The following are the UI components of this setup:
 - window manager: [hyprland](https://hyprland.org/)


### PR DESCRIPTION
The Kanagawa colour scheme URL was pointing to [Catppuccin](https://github.com/catppuccin/catppuccin), which is an excellent colour scheme but not the right one for Beneath the Surface. So, I've changed the URL to point to the Neovim Kanagawa theme, which is what I assumed is the Kanagawa inspiration mentioned.